### PR TITLE
Changed stderr to console.log

### DIFF
--- a/debug.ts
+++ b/debug.ts
@@ -1,4 +1,4 @@
-const { noColor, env, stderr } = Deno;
+const { noColor, env } = Deno;
 import format from "./format.ts";
 import { coerce, selectColor, regexpToNamespace } from "./utils.ts";
 
@@ -261,7 +261,7 @@ function updateNamespacesEnv(namespaces: string): void {
 // Default logger
 function log(...args: any[]): void {
   const result = format(...args);
-  stderr.write(new TextEncoder().encode(result + "\n"));
+  console.log(result);
 }
 
 // Exports


### PR DESCRIPTION
Some of the logs were not being printed out, I tried to move from stderr to stdout but the issue continued.
The only way I was able to get all the logs showing was by using console.log instead of stderr.
I was not able to understand why it happened.
In terms of testing, I've put a console.log on the `function log(...args: any[]): void {` just before the stderr, and I was getting the logs from that but not from stderr.
I've created this small PR so that you can also check if you have the same issue.
