### PR TITLE
fix: let it compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Then run your app.
 ## Notes
 
 - Currently debug assumes it is TTY and shows colors by default.
-- Deno's `inspect` differs from node's `util.inspect` so the output may not be the same.
-- We're using a custom `format` function ported from `util`. Might be cool to extract it when `util` is ported entirely.
+- Deno's `inspect` differs from node's `util.inspect` so the output may not be
+  the same.
+- We're using a custom `format` function ported from `util`. Might be cool to
+  extract it when `util` is ported entirely.
 - We should cover more functionality with tests.

--- a/debug.ts
+++ b/debug.ts
@@ -1,11 +1,11 @@
 const { noColor } = Deno;
 import { ms } from "https://deno.land/x/ms/ms.ts";
 import format from "./format.ts";
-import { coerce, selectColor, regexpToNamespace } from "./utils.ts";
+import { coerce, regexpToNamespace, selectColor } from "./utils.ts";
 
 const DEBUG = {
-  debug: ''
-}
+  debug: "",
+};
 
 interface DebugInstance {
   (log: string | Error, ...args: any[]): void;

--- a/demo.ts
+++ b/demo.ts
@@ -1,7 +1,7 @@
 import debug from "./debug.ts";
 
 function sleep(ms: number) {
-  return new Promise((r) => {
+  return new Promise<void>((r) => {
     setTimeout(() => r(), ms);
   });
 }

--- a/format_test.ts
+++ b/format_test.ts
@@ -1,7 +1,5 @@
 // Copied from https://github.com/defunctzombie/node-util/blob/master/test/node/format.js
-import {
-  assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 import format from "./format.ts";
 
 Deno.test("testFormat", function () {

--- a/utils.ts
+++ b/utils.ts
@@ -95,23 +95,9 @@ export function selectColor(namespace: string): number {
   return colors[Math.abs(hash) % colors.length];
 }
 
-/**
- * Build up the default `inspectOpts` object from the environment variables.
- * Used in `deno.inspect` in node.
- * Checkout deno source code for `inspect`: https://github.com/denoland/deno/blob/master/js/console.ts
- *
- * $ DEBUG_COLORS=no DEBUG_DEPTH=10 DEBUG_SHOW_HIDDEN=enabled node script.js
- */
-export interface InspectOpts {
-  hideDate?: boolean | null;
-  colors?: boolean | null;
-  depth?: number;
-  showHidden?: boolean | null;
-}
-
-export function getInspectOpts(): InspectOpts {
+export function getInspectOpts(): Deno.InspectOptions {
   const currentEnv = env.toObject();
-  const inspectOpts: InspectOpts = Object.keys(currentEnv)
+  const inspectOpts: Deno.InspectOptions = Object.keys(currentEnv)
     .filter((key) => /^debug_/i.test(key))
     .reduce((obj: { [key: string]: number | boolean | null }, key) => {
       const prop = camelCase(key.slice(6));


### PR DESCRIPTION
Fixes errors such as this in deno 1.8.3:

```
TS2345 [ERROR]: Argument of type 'InspectOpts' is not assignable to parameter of type 'InspectOptions'.
  Types of property 'colors' are incompatible.
    Type 'boolean | null | undefined' is not assignable to type 'boolean | undefined'.
      Type 'null' is not assignable to type 'boolean | undefined'.
      objects.push(inspect(arguments[i], inspectOpts));
```